### PR TITLE
Fix broken polymer project link

### DIFF
--- a/polymer-filters.html
+++ b/polymer-filters.html
@@ -17,7 +17,7 @@
 <script src="filter-length.js"></script>
 
 <!--
-A collection of filters for formatting values of [Polymer expressions](www.polymer-project.org/docs/polymer/expressions.html) for display to users.
+A collection of filters for formatting values of [Polymer expressions](http://www.polymer-project.org/docs/polymer/expressions.html) for display to users.
 
 ### Examples
 


### PR DESCRIPTION
The current url is relative causing a broken link in the deployed page.
