### PR TITLE
Add check to ensure trim does not error

### DIFF
--- a/filter-trim.js
+++ b/filter-trim.js
@@ -4,5 +4,5 @@
  * @return {string} trimmed string
  */
 PolymerExpressions.prototype.trim = function(input){
-	return input.replace(/^\s*|\s*$/g, '');
+  return input && input.replace(/^\s*|\s*$/g, '');
 }


### PR DESCRIPTION
- checks that input exists before attempting regex
- silences a thrown error
  - seems to keep with spirit of template filters, if value is not provided no need to throw an error
