### PR TITLE
Add Object.keys filter

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -114,6 +114,9 @@
     <h3>underscore</h3>
     {{'UserName' | underscore}}
 
+    <h3>objectKeys</h3>
+    {{{x: 1, y: 2} | objectKeys}}
+
 </template>
   <script>
 	var template = document.getElementById('view');

--- a/filter-objectKeys.js
+++ b/filter-objectKeys.js
@@ -1,0 +1,9 @@
+/**
+ * Transform an object into an array of its enumerable property names. Treats
+ * null or undefined as the empty object (and so returns an empty array).
+ * @param  {object} obj
+ * @return {array}
+ */
+PolymerExpressions.prototype.objectKeys = function(obj) {
+  return obj ? Object.keys(obj) : [];
+};

--- a/polymer-filters.html
+++ b/polymer-filters.html
@@ -193,6 +193,12 @@ A collection of filters for formatting values of [Polymer expressions](http://ww
 
 > user
 
+####Object.keys
+
+    {{{x: 1, y: 2} | objectKeys}}
+
+> ["x", "y"]
+
 
 @element polymer-filters
 @blurb A collection of Polymer filters for formatting values of expressions for display to users


### PR DESCRIPTION
This has come up a couple of times for me; seems useful.

Coercing falsey values to `{}` may not be the best choice, but `Object.keys` throws on e.g. `undefined` and `null`, so *some* coercion needs to happen. Maybe it would make more sense to return those values unchanged?