### PR TITLE
Remove useless comma, which lead to bower install failed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "**/.*"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#>=0.4.0 <1.0.0",
+    "polymer": "Polymer/polymer#>=0.4.0 <1.0.0"
   },
   "devDependencies": {
     "mocha": "~2.1.0",


### PR DESCRIPTION
The comma lead to bower install failed?