### PR TITLE
Make it easier to format currency without decimal places

### DIFF
--- a/filter-currency.js
+++ b/filter-currency.js
@@ -11,7 +11,9 @@ PolymerExpressions.prototype.currency = function (input, currency, precision) {
 		return "Value is not a Number";
 	} else {
 		currency = currency || "$";
-		precision = precision || 2;
+		if (typeof precision === 'undefined') {
+			precision = 2;
+		}
 
 		input = Number(input);
 		input = input.toFixed(precision);


### PR DESCRIPTION
I found it was difficult to get the currency filter to display with no decimal places, since `0 || 2` would evaluate to `2`.  Seems like a pretty valid use case, so I went ahead and fixed it up.

Workaround would be to pass in `'0'` instead of `0`, but I like this solution better.
